### PR TITLE
Respect animation blacklist when updating

### DIFF
--- a/src/win.c
+++ b/src/win.c
@@ -750,7 +750,10 @@ void win_process_update_flags(session_t *ps, struct managed_win *w) {
 			w->g = w->pending_g;
 
 		// Update window geometry
-		} else if (ps->o.animations) {
+		} else if (ps->o.animations
+				&& ps->o.wintype_option[w->window_type].animation != 0
+				&& !c2_match(ps, w, ps->o.animation_open_blacklist, NULL)) {
+
 			if (!was_visible) {
 				// Set window-open animation
 				init_animation(ps, w);


### PR DESCRIPTION
I wish to disable the animation effects of the fcitx input method because the experience of having a shaking animation every time a character is entered is not pleasant. When I added "class_g = 'fcitx'" to animation-open-exclude, I noticed that it did not take effect during updates. Therefore, I made this modification. There might be a better solution, but I am not familiar with this project, so I made the minimal changes.